### PR TITLE
chore: npm audit fix — bump transitive fast-uri to 3.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -730,9 +730,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Follow-up to #67. This commit was pushed to that branch but landed after GitHub had already synced the PR head, so the merge picked up only the first two commits and this one was left behind. `main` still has `fast-uri` 3.1.2 and `npm audit` still reports 1 high.

## The advisories

`fast-uri` 3.0.0 – 3.1.4, host confusion:

- [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx) — literal backslash authority delimiter
- [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) — backslash authority introducer
- [GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6) — failed IDN canonicalization

## Exposure

None for consumers. `fast-uri` is transitive through webpack → schema-utils → ajv, i.e. build tooling only, and the published tarball has zero runtime dependencies. This clears `npm audit` for anyone working in the repo.

## Scope

Lockfile-only — `npm audit fix`, 3 lines. No direct dependency versions changed, and `npm run build` produces a byte-identical `dist`. `npm audit` reports 0 vulnerabilities on this branch.

Not included: `typescript` 4.9.5 → 7.0.2 and `webpack-cli` 5.1.4 → 7.2.2. Major bumps, not security-driven, and they deserve their own build-validation PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)